### PR TITLE
issue#22 Fix birthday filters on Percona

### DIFF
--- a/CRM/Birthdays/Form/Report/Birthdays.php
+++ b/CRM/Birthdays/Form/Report/Birthdays.php
@@ -188,7 +188,7 @@ class CRM_Birthdays_Form_Report_Birthdays extends CRM_Report_Form {
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if ($fieldName == 'birthday') {
-            $field['name'] = "DATE_ADD({$this->_aliases['civicrm_contact']}.birth_date, INTERVAL YEAR(CURDATE() - INTERVAL 2 DAY) - YEAR({$this->_aliases['civicrm_contact']}.birth_date) + IF(DAYOFYEAR(CURDATE() - INTERVAL 2 DAY) >= DAYOFYEAR({$this->_aliases['civicrm_contact']}.birth_date),1,0) YEAR) ";
+            $field['name'] = "CAST(DATE_ADD({$this->_aliases['civicrm_contact']}.birth_date, INTERVAL YEAR(CURDATE() - INTERVAL 2 DAY) - YEAR({$this->_aliases['civicrm_contact']}.birth_date) + IF(DAYOFYEAR(CURDATE() - INTERVAL 2 DAY) >= DAYOFYEAR({$this->_aliases['civicrm_contact']}.birth_date),1,0) YEAR) AS DATETIME)";
           }
           elseif ($fieldName == 'age') {
             $field['dbAlias'] = "(YEAR(DATE_ADD({$this->_aliases['civicrm_contact']}.birth_date, INTERVAL YEAR(CURDATE() - INTERVAL 2 DAY) - YEAR({$this->_aliases['civicrm_contact']}.birth_date) + IF(DAYOFYEAR(CURDATE() - INTERVAL 2 DAY) >= DAYOFYEAR({$this->_aliases['civicrm_contact']}.birth_date),1,0) YEAR)) - YEAR({$this->_aliases['civicrm_contact']}.birth_date)) ";


### PR DESCRIPTION
Percona and MariaDB handle some date/datetime comparisons differently.

Comparisons of date with an 8 digit integer or string are the same and as desired:
MariaDB:
> select curdate(), curdate()>20210720, curdate()<20210720, curdate()<20210730, curdate()>'20210720', curdate()<'20210720', curdate()<'20210730';
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+
| curdate()  | curdate()>20210720 | curdate()<20210720 | curdate()<20210730 | curdate()>'20210720' | curdate()<'20210720' | curdate()<'20210730' |
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+
| 2021-07-27 |                  1 |                  0 |                  1 |                    1 |                    0 |                    1 |
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+

Percona:
> select curdate(), curdate()>20210720, curdate()<20210720, curdate()<20210730, curdate()>'20210720', curdate()<'20210720', curdate()<'20210730';
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+
| curdate()  | curdate()>20210720 | curdate()<20210720 | curdate()<20210730 | curdate()>'20210720' | curdate()<'20210720' | curdate()<'20210730' |
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+
| 2021-07-27 |                  1 |                  0 |                  1 |                    1 |                    0 |                    1 |
+------------+--------------------+--------------------+--------------------+----------------------+----------------------+----------------------+

However, comparing to a 14 digit datetime as string and integer produces different results:
MariaDB:
> select curdate(), curdate()>20210720235959, curdate()<20210720235959, curdate()<20210730235959, curdate()>'20210720235959', curdate()<'20210720235959', curdate()<'20210730235959';
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+
| curdate()  | curdate()>20210720235959 | curdate()<20210720235959 | curdate()<20210730235959 | curdate()>'20210720235959' | curdate()<'20210720235959' | curdate()<'20210730235959' |
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+
| 2021-07-27 |                        1 |                        0 |                        1 |                          1 |                          0 |                          1 |
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+

Percona:
> select curdate(), curdate()>20210720235959, curdate()<20210720235959, curdate()<20210730235959, curdate()>'20210720235959', curdate()<'20210720235959', curdate()<'20210730235959';
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+
| curdate()  | curdate()>20210720235959 | curdate()<20210720235959 | curdate()<20210730235959 | curdate()>'20210720235959' | curdate()<'20210720235959' | curdate()<'20210730235959' |
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+
| 2021-07-27 |                        0 |                        1 |                        1 |                          1 |                          0 |                          1 |
+------------+--------------------------+--------------------------+--------------------------+----------------------------+----------------------------+----------------------------+

Comparing a date with a datetime string produces the same, desired results but comparing a date to a datetime produces different results on Percona.

When filtering by birthdays in 'this calendar month', the comparison is against a 14 digit integer giving incorrect results on Percona, despite working
correctly on MariaDB.

The fix here is to convert the calculated date to a datetime before the comparison.

Observed on 10.3.29-MariaDB-0ubuntu0.20.10.1 and 5.7.31-percona-sure1-log